### PR TITLE
Correção listar_movimentos

### DIFF
--- a/omieapi/scripts/cod_automatico.py
+++ b/omieapi/scripts/cod_automatico.py
@@ -2008,7 +2008,7 @@ class CodigoAutogerado(OmieBase):
                 """  """
                 return self._chamar_api(
                     call= 'ListarMovimentos',
-                    endpoint= 'estoque/movestoque/',
+                    endpoint= 'financas/mf/',
                     param = kargs
                 )
             

--- a/omieapi/scripts/cod_automatico.py
+++ b/omieapi/scripts/cod_automatico.py
@@ -2004,11 +2004,11 @@ class CodigoAutogerado(OmieBase):
                     param = kargs
                 )
             
-    def listar_movimentos(self, **kargs) -> dict:
+    def listar_movimentos_estoque(self, **kargs) -> dict:
                 """  """
                 return self._chamar_api(
                     call= 'ListarMovimentos',
-                    endpoint= 'financas/mf/',
+                    endpoint= 'estoque/movestoque/',
                     param = kargs
                 )
             
@@ -3131,13 +3131,13 @@ class CodigoAutogerado(OmieBase):
                     endpoint= 'contador/xml/',
                     param = kargs
                 )
-    def listar_todos_movimentos(self, **kargs) -> dict:
+    def listar_movimentos_financas(self, **kargs) -> dict:
                 """ 	
                 Solicitação de Listagem da movimentação financeira (Contas a Pagar, Contas a Receber e Lançamentos do Conta Corrente).
                 """
                 return self._chamar_api(
                     call= 'ListarMovimentos',
-                    endpoint= 'financas/mf',
+                    endpoint= 'financas/mf/',
                     param = kargs
                 )
             


### PR DESCRIPTION
Corrigido o método listar_movimentos. A call ListarMovimentos é um método do endpoint financas/mf/, conforme página de exemplo https://app.omie.com.br/developer/api-test/?APP_KEY=38333295000&APP_SECRET=fed2163e2e8dccb53ff914ce9e2f1258&ENDPOINT=https%3A%2F%2Fapp.omie.com.br%2Fapi%2Fv1%2Ffinancas%2Fmf%2F&OMIE_CALL=ListarMovimentos&PARAMS=%257B%2B%2B%2522nPagina%2522%253A%2B1%252C%2B%2B%2522nRegPorPagina%2522%253A%2B500%257D